### PR TITLE
Documentation was added "how to sign mcu image"  in the signing_utilities section of rustBoot book

### DIFF
--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -202,3 +202,16 @@ BOOTSEL
 QSPI
 Pico's
 eabi
+prioritizes
+prioritize
+initializes
+initialize
+mcu's
+initialization
+cryptographically
+minimize
+optimized
+xxAA
+cryptographic
+executables
+customize

--- a/src/arch/signing_utilities.md
+++ b/src/arch/signing_utilities.md
@@ -6,23 +6,151 @@ As rustBoot supports 2 types of firmware image formats, depending on the underly
 
 rustBoot `rbsigner` utility can produce 2 different types signed images. 
 ### Signed mcu-image:
-To sign mcu-image, rustBoot's [image signing utility](https://github.com/nihalpasham/rustBoot/tree/main/rbsigner) takes 3 inputs
+To sign a mcu-image, rustBoot's [image signing utility](https://github.com/nihalpasham/rustBoot/tree/main/rbsigner) takes 3 inputs
 - an unsigned mcu-image. 
 - a raw signing-key or ecdsa private key.
 - the ecdsa curve-type - (nistp256 only for now).
 
-Following ways to sign mcu-image
+There are 2 ways to sign mcu-image
 
 - First we build the image and then sign it using the following commands.
 ```
  cargo [board-name] build pkgs-for
 
- cargo [board-name] sign pkgs-for 
+ cargo [board-name] sign pkgs-for [boot-version] [update-version]
 ``` 
+
+```
+Note : Here stm32f411 is used as example board for signing.
+```
+
+```
+output:
+command : cargo stm32f411 build pkgs-for
+
+yashwanthsingh@Yashwanths-MBP rustBoot % cargo stm32f411 build pkgs-for
+    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
+     Running `target/debug/xtask stm32f411 build pkgs-for`
+$ cargo build --release
+warning: unused config key `build.runner` in `/Users/yashwanthsingh/Yash/Projects/git_rustBoot_mcusigner/rustBoot/boards/firmware/stm32f411/boot_fw_blinky_green/.cargo/config.toml`
+    Finished release [optimized] target(s) in 0.08s
+$ cargo build --release
+warning: unused config key `build.runner` in `/Users/yashwanthsingh/Yash/Projects/git_rustBoot_mcusigner/rustBoot/boards/firmware/stm32f411/updt_fw_blinky_red/.cargo/config.toml`
+    Finished release [optimized] target(s) in 0.08s
+$ cargo build --release
+    Finished release [optimized] target(s) in 0.07s
+```
+
+```
+output:
+  command : cargo stm32f411 sign pkgs-for 1234 1235
+
+
+  yashwanthsingh@Yashwanths-MBP rustBoot % cargo stm32f411 sign pkgs-for 1234 1235
+    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
+     Running `target/debug/xtask stm32f411 sign pkgs-for 1234 1235`
+$ rust-objcopy -I elf32-littlearm ../../target/thumbv7em-none-eabihf/release/stm32f411_bootfw -O binary stm32f411_bootfw.bin
+$ rust-objcopy -I elf32-littlearm ../../target/thumbv7em-none-eabihf/release/stm32f411_updtfw -O binary stm32f411_updtfw.bin
+$ cargo run mcu-image ../boards/sign_images/signed_images/stm32f411_bootfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1234
+    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
+     Running `/Users/yashwanthsingh/Yash/Projects/git_rustBoot_mcusigner/rustBoot/target/debug/rbsigner mcu-image ../boards/sign_images/signed_images/stm32f411_bootfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1234`
+
+Update type:    Firmware
+Curve type:       nistp256
+Input image:      stm32f411_bootfw.bin
+Public key:       ecc256.der
+Image version:    1234
+Output image:     stm32f411_bootfw_v1234_signed.bin
+Calculating sha256 digest...
+Signing the firmware...
+Done.
+Output image successfully created with 1908 bytes.
+
+$ cargo run mcu-image ../boards/sign_images/signed_images/stm32f411_updtfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1235
+    Finished dev [unoptimized + debuginfo] target(s) in 0.05s
+     Running `/Users/yashwanthsingh/Yash/Projects/git_rustBoot_mcusigner/rustBoot/target/debug/rbsigner mcu-image ../boards/sign_images/signed_images/stm32f411_updtfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1235`
+
+Update type:    Firmware
+Curve type:       nistp256
+Input image:      stm32f411_updtfw.bin
+Public key:       ecc256.der
+Image version:    1235
+Output image:     stm32f411_updtfw_v1235_signed.bin
+Calculating sha256 digest...
+Signing the firmware...
+Done.
+Output image successfully created with 1996 bytes.  
+
+```
 - Single command to build ,sign and flash.
 
 ```
 cargo [board-name] build-sign-flash rustBoot [boot-ver] [updt-ver]
+```
+
+```
+output : 
+
+command : cargo stm32f411 build-sign-flash rustBoot 1234 1235
+yashwanthsingh@Yashwanths-MacBook-Pro rustBoot % cargo stm32f411 build-sign-flash rustBoot 1234 1235
+    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
+     Running `target/debug/xtask stm32f411 build-sign-flash rustBoot 1234 1235`
+$ cargo build --release
+warning: unused config key `build.runner` in `/Users/yashwanthsingh/Yash/Projects/git_rustBoot_mcusigner/rustBoot/boards/firmware/stm32f411/boot_fw_blinky_green/.cargo/config.toml`
+    Finished release [optimized] target(s) in 0.10s
+$ cargo build --release
+warning: unused config key `build.runner` in `/Users/yashwanthsingh/Yash/Projects/git_rustBoot_mcusigner/rustBoot/boards/firmware/stm32f411/updt_fw_blinky_red/.cargo/config.toml`
+    Finished release [optimized] target(s) in 0.10s
+$ cargo build --release
+    Finished release [optimized] target(s) in 0.11s
+$ rust-objcopy -I elf32-littlearm ../../target/thumbv7em-none-eabihf/release/stm32f411_bootfw -O binary stm32f411_bootfw.bin
+$ rust-objcopy -I elf32-littlearm ../../target/thumbv7em-none-eabihf/release/stm32f411_updtfw -O binary stm32f411_updtfw.bin
+$ cargo run mcu-image ../boards/sign_images/signed_images/stm32f411_bootfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1234
+    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
+     Running `/Users/yashwanthsingh/Yash/Projects/git_rustBoot_mcusigner/rustBoot/target/debug/rbsigner mcu-image ../boards/sign_images/signed_images/stm32f411_bootfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1234`
+
+Update type:    Firmware
+Curve type:       nistp256
+Input image:      stm32f411_bootfw.bin
+Public key:       ecc256.der
+Image version:    1234
+Output image:     stm32f411_bootfw_v1234_signed.bin
+Calculating sha256 digest...
+Signing the firmware...
+Done.
+Output image successfully created with 1908 bytes.
+
+$ cargo run mcu-image ../boards/sign_images/signed_images/stm32f411_updtfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1235
+    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
+     Running `/Users/yashwanthsingh/Yash/Projects/git_rustBoot_mcusigner/rustBoot/target/debug/rbsigner mcu-image ../boards/sign_images/signed_images/stm32f411_updtfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1235`
+
+Update type:    Firmware
+Curve type:       nistp256
+Input image:      stm32f411_updtfw.bin
+Public key:       ecc256.der
+Image version:    1235
+Output image:     stm32f411_updtfw_v1235_signed.bin
+Calculating sha256 digest...
+Signing the firmware...
+Done.
+Output image successfully created with 1996 bytes.
+
+$ probe-rs-cli erase --chip stm32f411vetx
+$ probe-rs-cli download --format Bin --base-address 0x8020000 --chip stm32f411vetx stm32f411_bootfw_v1234_signed.bin
+     Erasing sectors ✔ [00:00:01] [############################] 128.00KiB/128.00KiB @ 65.02KiB/s (eta 0s )
+ Programming pages   ✔ [00:00:00] [##############################]  2.00KiB/ 2.00KiB @     677B/s (eta 0s )
+    Finished in 2.057s
+$ probe-rs-cli download --format Bin --base-address 0x8040000 --chip stm32f411vetx stm32f411_updtfw_v1235_signed.bin
+     Erasing sectors ✔ [00:00:01] [############################] 128.00KiB/128.00KiB @ 65.15KiB/s (eta 0s )
+ Programming pages   ✔ [00:00:00] [##############################]  2.00KiB/ 2.00KiB @     679B/s (eta 0s )
+    Finished in 2.052s
+$ cargo flash --chip stm32f411vetx --release
+    Finished release [optimized] target(s) in 0.08s
+    Flashing /Users/yashwanthsingh/Yash/Projects/git_rustBoot_mcusigner/rustBoot/boards/target/thumbv7em-none-eabihf/release/stm32f411
+     Erasing sectors ✔ [00:00:01] [##############################] 48.00KiB/48.00KiB @ 40.79KiB/s (eta 0s )
+ Programming pages   ✔ [00:00:01] [##############################] 43.00KiB/43.00KiB @ 17.31KiB/s (eta 0s )
+    Finished in 2.267s
+yashwanthsingh@Yashwanths-MacBook-Pro rustBoot % 
 ```
 
 ### Signed fit-image:

--- a/src/arch/signing_utilities.md
+++ b/src/arch/signing_utilities.md
@@ -11,7 +11,7 @@ To sign a mcu-image, rustBoot's [image signing utility](https://github.com/nihal
 - a raw signing-key or ecdsa private key.
 - the ecdsa curve-type - (nistp256 only for now).
 
-There are 2 ways to sign mcu-image
+There are 2 ways to sign a mcu-image
 
 - First we build the image and then sign it using the following commands.
 ```

--- a/src/arch/signing_utilities.md
+++ b/src/arch/signing_utilities.md
@@ -6,7 +6,25 @@ As rustBoot supports 2 types of firmware image formats, depending on the underly
 
 rustBoot `rbsigner` utility can produce 2 different types signed images. 
 ### Signed mcu-image:
-    [TODO ..]
+To sign mcu-image, rustBoot's [image signing utility](https://github.com/nihalpasham/rustBoot/tree/main/rbsigner) takes 3 inputs
+- an unsigned mcu-image. 
+- a raw signing-key or ecdsa private key.
+- the ecdsa curve-type - (nistp256 only for now).
+
+Following ways to sign mcu-image
+
+- First we build the image and then sign it using the following commands.
+```
+ cargo [board-name] build pkgs-for
+
+ cargo [board-name] sign pkgs-for 
+``` 
+- Single command to build ,sign and flash.
+
+```
+cargo [board-name] build-sign-flash rustBoot [boot-ver] [updt-ver]
+```
+
 ### Signed fit-image:
 To sign a fit-image, rustBoot's [image signing utility](https://github.com/nihalpasham/rustBoot/tree/main/rbsigner) takes 3 inputs 
 - an unsigned fit-image in the above format


### PR DESCRIPTION
Steps were added how to sign mcu image in rustBoot Book.

1. Signing using multiple command.
2. Signing using Single command.

Following changes were made as per discussed

1. Output was added for signing the image.
3. Grammatical errors were resolved.