### PR TITLE
Add documentation for STM32F469-IDISCO board

### DIFF
--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -164,6 +164,7 @@ llvm
 toolchains
 microsoft
 EDISCOVERY
+IDISCOVERY
 swappable
 dddf
 Bobbili
@@ -215,3 +216,4 @@ xxAA
 cryptographic
 executables
 customize
+NIHx

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -25,10 +25,10 @@
     - [rpi4](usage/rpi4.md)
     - [stm32f411](usage/stm32f411.md)
     - [stm32f446](usage/stm32f446.md)
+    - [stm32f469](usage/stm32f469.md)
     - [stm32h723](usage/stm32h723.md)
     - [stm32f746](usage/stm32f746.md)
     - [stm32f334](usage/stm32f334.md)
-
 
 # Coding Guidelines and Testing
 

--- a/src/usage/stm32f469.md
+++ b/src/usage/stm32f469.md
@@ -1,6 +1,6 @@
 # `stm32f469`
 
-The `stm32f469` example uses a [STM32F469-IDISCOVERY BOARD](https://www.st.com/en/evaluation-tools/32f469idiscovery.html). The board has four front LEDs of which thress LEDs are used in this example. 
+The `stm32f469` example uses a [STM32F469-IDISCOVERY BOARD](https://www.st.com/en/evaluation-tools/32f469idiscovery.html). The board has four front LEDs, three of which are used in this example. 
 
 > Note:
 > - If you're using a different version of the board, you'll probably need to edit your firmware's `partition-addresses` to accommodate for differences. 

--- a/src/usage/stm32f469.md
+++ b/src/usage/stm32f469.md
@@ -131,7 +131,7 @@ lionel@saturn:/tmp/rustBoot$
 ```
 ## Verifying:
 
-`blinky leds` are used to confirm that rustBoot works as expected. On the STM32F469-IDISCO board, the LEDs we are referring to below correspond to the LEDs next to the LCD screen. Here's the flow
+`blinky leds` are used to confirm that rustBoot works as expected. On the STM32F469-IDISCOVERY board, the LEDs we are referring to below correspond to the LEDs next to the LCD screen. Here's the flow
 
 - After flashing the demo, upon supplying power to the board or pressing the black (reset) button, rustBoot takes over 
     - validates the firmware image stored in the BOOT partition

--- a/src/usage/stm32f469.md
+++ b/src/usage/stm32f469.md
@@ -1,0 +1,149 @@
+# `stm32f469`
+
+The `stm32f469` example uses a [STM32F469-IDISCOVERY BOARD](https://www.st.com/en/evaluation-tools/32f469idiscovery.html). The board has four front LEDs of which thress LEDs are used in this example. 
+
+> Note:
+> - If you're using a different version of the board, you'll probably need to edit your firmware's `partition-addresses` to accommodate for differences. 
+> - Just make sure you don't change the names of files or the folder structure, as cargo xtask looks for these file/folder names.
+> - On the discovery board, an external 1Mb N25Q128A flash is available in addition to the STM32 internal flash, but we won't use that storage in this example.
+
+## Partitioning:
+
+The first step in integrating rustBoot is `flash-memory partitioning` i.e. we divide the `stm32f469`'s flash-memory into 4 partitions, taking into account the geometry of the flash memory. 
+
+> You can read more about `mcu` partitioning [here](../arch/partitions.md#micro-controller-partitions)
+
+In this example, we'll be using the following partitioning scheme. You can locate these constants in the [constants module](https://github.com/nihalpasham/rustBoot/blob/main/rustBoot/src/constants.rs)
+
+```rust
+#[cfg(feature = "stm32f469")]
+pub const SECTOR_SIZE: usize = 0x20000;
+#[cfg(feature = "stm32f469")]
+pub const PARTITION_SIZE: usize = 0x60000;
+#[cfg(feature = "stm32f469")]
+pub const BOOT_PARTITION_ADDRESS: usize = 0x08020000;
+#[cfg(feature = "stm32f469")]
+pub const UPDATE_PARTITION_ADDRESS: usize = 0x08080000;
+#[cfg(feature = "stm32f469")]
+pub const SWAP_PARTITION_ADDRESS: usize = 0x080e0000;
+```
+- **`RUSTBOOT partition:`** contains the bootloader (its code and data) and a (test) public-key embedded as part of the bootloader image, starts at address `0x0800_0000`.
+- **`BOOT partition:`** contains boot firmware, starts at address `PARTITION_BOOT_ADDRESS`.
+- **`UPDATE partition:`** contains update firmware, starts at address `UPDATE_PARTITION_ADDRESS`. The boot firmware is responsible for downloading and installing the update firmware into this partition via a secure channel.
+- **`SWAP partition:`** is the temporary swap space, starts at address `SWAP_PARTITION_ADDRESS`. 
+
+## Compiling, Signing and Programming: 
+
+Now that we have properly partitioned the `stm32f469`'s on-board flash-memory, the next step is - `compiling, signing and programming ` 
+
+We will compile the following 
+- bootloader 
+- boot and update firmware
+
+sign both pieces of firmware with a (test) [private-key](https://github.com/nihalpasham/rustBoot/tree/main/boards/rbSigner/keygen) and finally create valid [`rustBoot mcu-images`](../arch/images.md#mcu-image-format) i.e. signed boot and update firmware images.
+
+> Note:
+> - the `ecc256.der` file contains a public-key and a private-key, the first 64 bytes being the public-key and remaining 32 bytes make up the private-key. 
+> - This is a test key file and is to be used for testing purposes only.
+
+Compiling, signing and programming can be performed via a single command
+
+```MAC
+cargo stm32f469 build-sign-flash rustBoot [boot-ver] [updt-ver]
+```
+> Note:
+> - The `updt-ver` number should be greater than `boot-ver`.
+
+
+This will build, sign and flash all 3 packages (i.e. bootloader + boot-fw + update-fw) onto the board.
+
+> Note: 
+> - The corresponding public-key is embedded in the bootloader's source.
+> - In order to test this example, you'll have to install a couple of pre-requisites  as it uses probe-run to flash the binary.
+```
+ cargo install probe-rs-cli 
+ cargo install cargo-flash 
+ cargo install cargo-binutils
+```
+
+Here's the command line output that should be produced.
+
+```
+lionel@saturn:/tmp/rustBoot$ cargo stm32f469 build-sign-flash rustBoot 1234 1235
+    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
+     Running `target/debug/xtask stm32f469 build-sign-flash rustBoot 1234 1235`
+$ cargo build --release
+warning: unused config key `build.runner` in `/tmp/rustBoot/boards/firmware/stm32f469/boot_fw_blinky_green/.cargo/config.toml`
+    Finished release [optimized] target(s) in 0.05s
+$ cargo build --release
+warning: unused config key `build.runner` in `/tmp/rustBoot/boards/firmware/stm32f469/updt_fw_blinky_red/.cargo/config.toml`
+    Finished release [optimized] target(s) in 0.04s
+$ cargo build --release
+    Finished release [optimized] target(s) in 0.04s
+$ rust-objcopy -I elf32-littlearm ../../target/thumbv7em-none-eabihf/release/stm32f469_bootfw -O binary stm32f469_bootfw.bin
+$ rust-objcopy -I elf32-littlearm ../../target/thumbv7em-none-eabihf/release/stm32f469_updtfw -O binary stm32f469_updtfw.bin
+$ cargo run mcu-image ../boards/sign_images/signed_images/stm32f469_bootfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1234
+    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
+     Running `/tmp/rustBoot/target/debug/rbsigner mcu-image ../boards/sign_images/signed_images/stm32f469_bootfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1234`
+
+Image type:       mcu-image
+Curve type:       nistp256
+Input image:      stm32f469_bootfw.bin
+Public key:       ecc256.der
+Image version:    1234
+Output image:     stm32f469_bootfw_v1234_signed.bin
+Calculating sha256 digest...
+Signing the firmware...
+Done.
+Output image successfully created with 2004 bytes.
+
+$ cargo run mcu-image ../boards/sign_images/signed_images/stm32f469_updtfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1235
+    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
+     Running `/tmp/rustBoot/target/debug/rbsigner mcu-image ../boards/sign_images/signed_images/stm32f469_updtfw.bin nistp256 ../boards/sign_images/keygen/ecc256.der 1235`
+
+Image type:       mcu-image
+Curve type:       nistp256
+Input image:      stm32f469_updtfw.bin
+Public key:       ecc256.der
+Image version:    1235
+Output image:     stm32f469_updtfw_v1235_signed.bin
+Calculating sha256 digest...
+Signing the firmware...
+Done.
+Output image successfully created with 2232 bytes.
+
+$ probe-rs-cli erase --chip STM32F469NIHx
+$ probe-rs-cli download --format Bin --base-address 0x8020000 --chip STM32F469NIHx stm32f469_bootfw_v1234_signed.bin
+     Erasing sectors ✔ [00:00:02] [##############################################################################################################] 128.00KiB/128.00KiB @ 60.69KiB/s (eta 0s )
+ Programming pages   ✔ [00:00:00] [################################################################################################################]  2.00KiB/ 2.00KiB @     630B/s (eta 0s )
+    Finished in 2.249s
+$ probe-rs-cli download --format Bin --base-address 0x8080000 --chip STM32F469NIHx stm32f469_updtfw_v1235_signed.bin
+     Erasing sectors ✔ [00:00:02] [##############################################################################################################] 128.00KiB/128.00KiB @ 60.92KiB/s (eta 0s )
+ Programming pages   ✔ [00:00:00] [################################################################################################################]  3.00KiB/ 3.00KiB @     772B/s (eta 0s )
+    Finished in 2.244s
+$ cargo flash --chip STM32F469NIHx --release
+    Finished release [optimized] target(s) in 0.07s
+    Flashing /tmp/rustBoot/boards/target/thumbv7em-none-eabihf/release/stm32f469
+     Erasing sectors ✔ [00:00:01] [################################################################################################################] 48.00KiB/48.00KiB @ 39.74KiB/s (eta 0s )
+ Programming pages   ✔ [00:00:01] [################################################################################################################] 40.00KiB/40.00KiB @ 14.95KiB/s (eta 0s )
+    Finished in 2.443s
+lionel@saturn:/tmp/rustBoot$
+```
+## Verifying:
+
+`blinky leds` are used to confirm that rustBoot works as expected. On the STM32F469-IDISCO board, the LEDs we are referring to below correspond to the LEDs next to the LCD screen. Here's the flow
+
+- After flashing the demo, upon supplying power to the board or pressing the black (reset) button, rustBoot takes over 
+    - validates the firmware image stored in the BOOT partition
+    - verifies the signature attached against a known public key stored in the rustBoot image.
+- If the signature checks out, rustBoot boots into the bootfw and blinks a `green-led` for a few seconds, 
+    - post which, the boot firmware triggers the update and performs a system reset. 
+- Upon reset, the rustBoot again takes over 
+    - validates the firmware image stored in the UPDATE partition 
+    - swaps the contents of the BOOT and the UPDATE partitions
+    - marks the new firmware in the BOOT partition as in state STATE_TESTING
+    - boots into the UPDATE'd firmware 
+- Now that execution-control has been transferred to the UPDATE'd firmware
+    - it will attempt to blink a `red-led` 
+    - and set a `confirmation flag` to indicate that the update was successful.
+    - post which, it will also turn on a `blue-led` and continue blinking a `red-led`.

--- a/src/usage/stm32f469.md
+++ b/src/usage/stm32f469.md
@@ -5,7 +5,7 @@ The `stm32f469` example uses a [STM32F469-IDISCOVERY BOARD](https://www.st.com/e
 > Note:
 > - If you're using a different version of the board, you'll probably need to edit your firmware's `partition-addresses` to accommodate for differences. 
 > - Just make sure you don't change the names of files or the folder structure, as cargo xtask looks for these file/folder names.
-> - On the discovery board, an external 1Mb N25Q128A flash is available in addition to the STM32 internal flash, but we won't use that storage in this example.
+> - On the discovery board, an external 1MB N25Q128A flash is mounted (in addition to the STM32 internal 1MB flash), but we will only use the internal flash in this example.
 
 ## Partitioning:
 


### PR DESCRIPTION
This documents the rustBoot upgrade example for the STM32F469-IDISCO, based on the STM32F469 support added in https://github.com/nihalpasham/rustBoot/pull/65